### PR TITLE
Bumping up the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@thoughtspot/graph-to-openapi",
-    "version": "0.6.4",
+    "version": "0.7.5",
     "description": "Get an OpenAPI 3.0 spec out of a graphql Schema",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
Bumping up the version
There was discrepancy between npm version published with package.json. So aligning it to the right version number